### PR TITLE
Improve output when delete_snapshot is blocked by task

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1188,7 +1188,7 @@ class DeleteSnapshots(object):
         ):
                 raise exceptions.FailedExecution(
                     'Unable to delete snapshot(s) because a snapshot is in '
-                    'state "IN_PROGRESS"')
+                    'state "IN_PROGRESS" or other snapshot activity was detected')
         try:
             for snap in self.snapshot_list.snapshots:
                 self.loggit.info('Deleting snapshot {0}...'.format(snap))

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1196,15 +1196,14 @@ def find_snapshot_tasks(client):
     :arg client: An :class:`opensearchpy.Opensearch` client object
     :rtype: bool
     """
-    retval = False
     tasklist = client.tasks.list()
     for node in tasklist['nodes']:
         for task in tasklist['nodes'][node]['tasks']:
             activity = tasklist['nodes'][node]['tasks'][task]['action']
             if 'snapshot' in activity:
                 LOGGER.debug('Snapshot activity detected: {0}'.format(activity))
-                retval = True
-    return retval
+                return tasklist['nodes'][node]['tasks'][task]
+    return False
 
 def safe_to_snap(client, repository=None, retry_interval=120, retry_count=3):
     """
@@ -1229,7 +1228,8 @@ def safe_to_snap(client, repository=None, retry_interval=120, retry_count=3):
                 LOGGER.info(
                     'Snapshot already in progress: {0}'.format(in_progress))
             elif ongoing_task:
-                LOGGER.info('Snapshot activity detected in Tasks API')
+                LOGGER.info(
+                    'Snapshot activity detected in Tasks API: {0}'.format(ongoing_task))
             LOGGER.info(
                 'Pausing {0} seconds before retrying...'.format(retry_interval))
             time.sleep(retry_interval)


### PR DESCRIPTION
Currently if another snapshot task is blocking delete_snapshot, the task action is logged as DEBUG only and following is logged at the INFO level:
```console
Unable to delete snapshot(s) because a snapshot is in state "IN_PROGRESS"
```
If there is actually another snapshot in progress, this message is accurate, but this message is _also_ thrown if there are any other tasks with actions containing the word "snapshot" in the tasks list.

This PR makes the following changes:
1. In `utils/find_snapshot_tasks`: Return the whole task object instead of `True` if there is an active snapshot task
2. In `utils/safe_to_snap`: Print the contents of the active snapshot task object if there is one.
3. In `actions/DeleteSnapshots/do_action`: Change the wording of the error message to allow for failure due to "other snapshot activity" (and not just in progress snapshots).