### PR TITLE
Make the meaning of `retry_count` consistent

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1130,7 +1130,7 @@ class Rollover(object):
 
 class DeleteSnapshots(object):
     """Delete Snapshots Action Class"""
-    def __init__(self, slo, retry_interval=120, retry_count=3):
+    def __init__(self, slo, retry_interval=120, retry_count=2):
         """
         :arg slo: A :class:`curator.snapshotlist.SnapshotList` object
         :arg retry_interval: Number of seconds to delay betwen retries. Default:

--- a/curator/cli_singletons/delete.py
+++ b/curator/cli_singletons/delete.py
@@ -40,7 +40,7 @@ def delete_indices(ctx, ignore_empty_list, allow_ilm_indices, filter_list):
 #### Snapshots ####
 @click.command(context_settings=get_width())
 @click.option('--repository', type=str, required=True, help='Snapshot repository name')
-@click.option('--retry_count', type=int, help='Number of times to retry (max 3)')
+@click.option('--retry_count', type=int, help='Number of times to retry (max 100)')
 @click.option('--retry_interval', type=int, help='Time in seconds between retries')
 @click.option(
     '--ignore_empty_list',

--- a/curator/defaults/option_defaults.py
+++ b/curator/defaults/option_defaults.py
@@ -227,7 +227,7 @@ def requests_per_second():
     return {Optional('requests_per_second', default=-1): Any(-1, Coerce(int), None)}
 
 def retry_count():
-    return {Optional('retry_count', default=3): All(Coerce(int), Range(min=0, max=100))}
+    return {Optional('retry_count', default=2): All(Coerce(int), Range(min=0, max=100))}
 
 def retry_interval():
     return {Optional('retry_interval', default=120): All(Coerce(int), Range(min=1, max=600))}

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -1206,7 +1206,7 @@ def find_snapshot_tasks(client):
                 retval = True
     return retval
 
-def safe_to_snap(client, repository=None, retry_interval=120, retry_count=3):
+def safe_to_snap(client, repository=None, retry_interval=120, retry_count=2):
     """
     Ensure there are no snapshots in progress.  Pause and retry accordingly
 
@@ -1219,7 +1219,7 @@ def safe_to_snap(client, repository=None, retry_interval=120, retry_count=3):
     """
     if not repository:
         raise exceptions.MissingArgument('No value for "repository" provided')
-    for count in range(1, retry_count+1):
+    for count in range(1, retry_count+2):
         in_progress = snapshot_in_progress(
             client, repository=repository
         )

--- a/docs/asciidoc/actions.asciidoc
+++ b/docs/asciidoc/actions.asciidoc
@@ -445,7 +445,7 @@ description: "Delete selected snapshots from 'repository'"
 options:
   repository: ...
   retry_interval: 120
-  retry_count: 3
+  retry_count: 2
 filters:
 - filtertype: ...
 -------------

--- a/docs/asciidoc/options.asciidoc
+++ b/docs/asciidoc/options.asciidoc
@@ -2289,7 +2289,7 @@ description: "Delete selected snapshots from 'repository'"
 options:
   repository: ...
   retry_interval: 120
-  retry_count: 3
+  retry_count: 2
 filters:
 - filtertype: ...
 -------------
@@ -2312,7 +2312,7 @@ description: "Delete selected snapshots from 'repository'"
 options:
   repository: ...
   retry_interval: 120
-  retry_count: 3
+  retry_count: 2
 filters:
 - filtertype: ...
 -------------


### PR DESCRIPTION
### What this does
There seems to be internal confusion as to whether `retry_count` really means "tries", where 0--which is a legal value--means never try at all or "retries", where 0 means try once (but never "retry"). My assumption is that no one really intends to disable the action by setting `retry_count=0`.

This tries to clear that up by updating `safe_to_snap()` so `retry_count=1` results in exactly 1 try and by modifying the default to be 2 so as to preserve the current default behavior.