### PR TITLE
Fix some version checks to pass against opensearch 1.0.0

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1051,7 +1051,7 @@ class Rollover(object):
         """
         if 'max_size' in conditions:
             version = utils.get_version(self.client)
-            if version < (6, 1, 0):
+            if version < (1, 0, 0):
                 raise exceptions.ConfigurationError(
                     'Your version of elasticsearch ({0}) does not support '
                     'the max_size rollover condition. It is only supported '
@@ -1462,7 +1462,7 @@ class Reindex(object):
             'slices': self.slices
         }
         version = utils.get_version(self.client)
-        if version < (5, 1, 0):
+        if version < (1, 0, 0):
             self.loggit.info(
                 'Your version of elasticsearch ({0}) does not support '
                 'sliced scroll for reindex, so that setting will not be '
@@ -2103,7 +2103,7 @@ class Shrink(object):
         if extra_settings:
             self._merge_extra_settings(extra_settings)
 
-        if utils.get_version(self.client) >= (6, 1, 0):
+        if utils.get_version(self.client) >= (1, 0, 0):
             self._merge_extra_settings({
                 'settings': {
                     'index.routing.allocation.require._name': None,

--- a/curator/utils.py
+++ b/curator/utils.py
@@ -101,7 +101,7 @@ def rollable_alias(client, alias):
     # number, and 'value of "alias" here' reflects the value of the passed
     # parameter, except in versions 6.5.0+ where the ``is_write_index`` setting
     # makes it possible to have more than one index associated with a rollover index
-    if get_version(client) >= (6, 5, 0):
+    if get_version(client) >= (1, 0, 0):
         for idx in response:
             if 'is_write_index' in response[idx]['aliases'][alias]:
                 if response[idx]['aliases'][alias]['is_write_index']:


### PR DESCRIPTION
Update version checks throughout curator to allow rollover actions on opensearch version 1.0.0

Fixes #8 