### PR TITLE
Supports cx_Freeze >= 6.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,17 +55,17 @@ try:
     curator_exe = Executable(
         "run_curator.py",
         base=base,
-        targetName = "curator",
+        target_name = "curator",
     )
     curator_cli_exe = Executable(
         "run_singleton.py",
         base=base,
-        targetName = "curator_cli",
+        target_name = "curator_cli",
     )
     repomgr_exe = Executable(
         "run_es_repo_mgr.py",
         base=base,
-        targetName = "es_repo_mgr",
+        target_name = "es_repo_mgr",
     )
     build_dict = { 
         "build_exe": dict(
@@ -78,19 +78,19 @@ try:
         curator_exe = Executable(
             "run_curator.py",
             base=base,
-            targetName = "curator.exe",
+            target_name = "curator.exe",
             icon = icon
         )
         curator_cli_exe = Executable(
             "run_singleton.py",
             base=base,
-            targetName = "curator_cli.exe",
+            target_name = "curator_cli.exe",
             icon = icon
         )
         repomgr_exe = Executable(
             "run_es_repo_mgr.py",
             base=base,
-            targetName = "es_repo_mgr.exe",
+            target_name = "es_repo_mgr.exe",
             icon = icon
         )
 


### PR DESCRIPTION
The latest cx_Freeze  6.15 uses snake case rather than camel case which make Docker builder failed.

Reference: [link](https://github.com/marcelotduarte/cx_Freeze/pull/1809/commits/c6db4d02fa72f0aa385865f76666b87b9124c1d6) 